### PR TITLE
Fix deploy script

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -2,3 +2,4 @@
 rm -rf deployment
 rm -rf data
 rm -rf docker-compose.yml
+rm -rf .env

--- a/parity-deploy.sh
+++ b/parity-deploy.sh
@@ -126,7 +126,7 @@ build_docker_client() {
     cat config/docker/client.yml >> docker-compose.yml
 
     # writing client dependencies
-    if [ "$CHAIN_NODES" > "0" ] ; then
+    if [ "$CHAIN_NODES" -gt "0" ] ; then
       echo "       depends_on:" >> docker-compose.yml
 
       for x in ` seq 1 $CHAIN_NODES ` ; do
@@ -140,7 +140,7 @@ build_docker_client() {
 build_custom_chain() {
 
 
-  if [ "$CUSTOM_CHAIN" == "" ] ; then
+  if [ -z "$CUSTOM_CHAIN" ] ; then
      echo "Must specify argument for custom chain option."
      exit 1
   fi
@@ -190,7 +190,7 @@ expose_container() {
 
 select_exposed_container() {
 
-  if [ "$EXPOSE_CLIENT" != "" ] ; then
+  if [ -n "$EXPOSE_CLIENT" ] ; then
     expose_container $EXPOSE_CLIENT
   else
     if [ "$CLIENT" == "0" ] ; then
@@ -260,11 +260,9 @@ while [ "$1" != "" ]; do
         -r | --release)         shift
                                 PARITY_RELEASE=$1
                                 ;;
-        -e | --ethstats)        shift
-                                ETHSTATS=1
+        -e | --ethstats)        ETHSTATS=1
                                 ;;
-        --enable-client)        shift
-                                CLIENT=1
+        --enable-client)        CLIENT=1
                                 ;;
         --expose)               shift
                                 EXPOSE_CLIENT="$1"
@@ -280,7 +278,7 @@ while [ "$1" != "" ]; do
     shift
 done
 
-if [ "$CHAIN_ENGINE" == "" ] && [ "$CHAIN_NETWORK" == "" ]; then
+if [ -z "$CHAIN_ENGINE" ] && [ -z "$CHAIN_NETWORK" ]; then
     echo "No chain argument, exiting..."
     exit 1
 fi
@@ -289,9 +287,9 @@ fi
 
 # Get a copy of the parity binary, overwriting if release is set
 
-if [ ! -f /usr/bin/parity ] || [ ! "$PARITY_RELEASE" == "" ] ; then
+if [ ! -f /usr/bin/parity ] || [ -n "$PARITY_RELEASE" ] ; then
 
-        if [ "$PARITY_RELEASE" == "" ] ; then
+        if [ -z "$PARITY_RELEASE" ] ; then
                 echo "NO custom parity build set, downloading beta"
                 bash <(curl https://get.parity.io -Lk)
         else

--- a/parity-deploy.sh
+++ b/parity-deploy.sh
@@ -47,18 +47,20 @@ openssl rand -base64 12
 
 create_node_params() {
 
-if [ ! -d deployment/$1 ] ; then
-   mkdir -p deployment/$1
+local DEST_DIR=deployment/$1
+if [ ! -d $DEST_DIR ] ; then
+   mkdir -p $DEST_DIR
 fi
 
-genpw > deployment/$1/password
-./config/utils/keygen.sh deployment/$1
-sed -i "s/CHAIN_NAME/$CHAIN_NAME/g" config/spec/example.spec
-parity --chain config/spec/example.spec --keys-path deployment/$1/ account new --password deployment/$1/password  > deployment/$1/address.txt
-sed -i "s/$CHAIN_NAME/CHAIN_NAME/g" config/spec/example.spec
+genpw > $DEST_DIR/password
+./config/utils/keygen.sh $DEST_DIR
+
+local SPEC_FILE=$(mktemp -p $DEST_DIR spec.XXXXXXXXX)
+sed "s/CHAIN_NAME/$CHAIN_NAME/g" config/spec/example.spec > $SPEC_FILE
+parity --chain $SPEC_FILE --keys-path $DEST_DIR/ account new --password $DEST_DIR/password  > $DEST_DIR/address.txt
+rm $SPEC_FILE
+
 echo "NETWORK_NAME=$CHAIN_NAME" > .env
-
-
 
 }
 


### PR DESCRIPTION
Fix bugs and cleanup parity-deploy.sh and clean.sh

 * Remove extra `shift` that broke parsing of `ethstats` and `enable-client` options
 * Fix incorrect use of ">" instead of "-gt"
 * Use proper bash-isms (`-z` and `-n`) for testing empty strings
 * Use temp file instead of making a change & reverting the `example.spec` file
 * Fix `clean.sh` not removing the `.env` file