### PR TITLE
add byzantium and constantinople config by default

### DIFF
--- a/config/spec/accounts/aura
+++ b/config/spec/accounts/aura
@@ -3,5 +3,9 @@
         "0x0000000000000000000000000000000000000002": { "balance": "1", "builtin": { "name": "sha256", "pricing": { "linear": { "base": 60, "word": 12 } } } },
         "0x0000000000000000000000000000000000000003": { "balance": "1", "builtin": { "name": "ripemd160", "pricing": { "linear": { "base": 600, "word": 120 } } } },
         "0x0000000000000000000000000000000000000004": { "balance": "1", "builtin": { "name": "identity", "pricing": { "linear": { "base": 15, "word": 3 } } } },
-	"0x00Ea169ce7e0992960D3BdE6F5D539C955316432": { "balance": "1606938044258990275541962092341162602522202993782792835301376" }  
+        "0x0000000000000000000000000000000000000005": { "builtin": { "name": "modexp", "activate_at": "0x0", "pricing": { "modexp": { "divisor": 20 } } } },
+        "0x0000000000000000000000000000000000000006": { "builtin": { "name": "alt_bn128_add", "activate_at": "0x0", "pricing": { "linear": { "base": 500, "word": 0 } } } },
+        "0x0000000000000000000000000000000000000007": { "builtin": { "name": "alt_bn128_mul", "activate_at": "0x0", "pricing": { "linear": { "base": 40000, "word": 0 } } } },
+        "0x0000000000000000000000000000000000000008": { "builtin": { "name": "alt_bn128_pairing", "activate_at": "0x0", "pricing": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 } } } },
+        "0x00Ea169ce7e0992960D3BdE6F5D539C955316432": { "balance": "1606938044258990275541962092341162602522202993782792835301376" }
     }

--- a/config/spec/accounts/instantseal
+++ b/config/spec/accounts/instantseal
@@ -1,7 +1,11 @@
 	"accounts": {
-		"0000000000000000000000000000000000000001": { "balance": "1", "builtin": { "name": "ecrecover", "pricing": { "linear": { "base": 3000, "word": 0 } } } },
-		"0000000000000000000000000000000000000002": { "balance": "1", "builtin": { "name": "sha256", "pricing": { "linear": { "base": 60, "word": 12 } } } },
-		"0000000000000000000000000000000000000003": { "balance": "1", "builtin": { "name": "ripemd160", "pricing": { "linear": { "base": 600, "word": 120 } } } },
-		"0000000000000000000000000000000000000004": { "balance": "1", "builtin": { "name": "identity", "pricing": { "linear": { "base": 15, "word": 3 } } } },
+		"0x0000000000000000000000000000000000000001": { "balance": "1", "builtin": { "name": "ecrecover", "pricing": { "linear": { "base": 3000, "word": 0 } } } },
+		"0x0000000000000000000000000000000000000002": { "balance": "1", "builtin": { "name": "sha256", "pricing": { "linear": { "base": 60, "word": 12 } } } },
+		"0x0000000000000000000000000000000000000003": { "balance": "1", "builtin": { "name": "ripemd160", "pricing": { "linear": { "base": 600, "word": 120 } } } },
+		"0x0000000000000000000000000000000000000004": { "balance": "1", "builtin": { "name": "identity", "pricing": { "linear": { "base": 15, "word": 3 } } } },
+		"0x0000000000000000000000000000000000000005": { "builtin": { "name": "modexp", "activate_at": "0x0", "pricing": { "modexp": { "divisor": 20 } } } },
+		"0x0000000000000000000000000000000000000006": { "builtin": { "name": "alt_bn128_add", "activate_at": "0x0", "pricing": { "linear": { "base": 500, "word": 0 } } } },
+		"0x0000000000000000000000000000000000000007": { "builtin": { "name": "alt_bn128_mul", "activate_at": "0x0", "pricing": { "linear": { "base": 40000, "word": 0 } } } },
+		"0x0000000000000000000000000000000000000008": { "builtin": { "name": "alt_bn128_pairing", "activate_at": "0x0", "pricing": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 } } } },
 		"0x00Ea169ce7e0992960D3BdE6F5D539C955316432": { "balance": "1606938044258990275541962092341162602522202993782792835301376" }
 	}

--- a/config/spec/accounts/tendermint
+++ b/config/spec/accounts/tendermint
@@ -3,5 +3,9 @@
         "0x0000000000000000000000000000000000000002": { "balance": "1", "builtin": { "name": "sha256", "pricing": { "linear": { "base": 60, "word": 12 } } } },
         "0x0000000000000000000000000000000000000003": { "balance": "1", "builtin": { "name": "ripemd160", "pricing": { "linear": { "base": 600, "word": 120 } } } },
         "0x0000000000000000000000000000000000000004": { "balance": "1", "builtin": { "name": "identity", "pricing": { "linear": { "base": 15, "word": 3 } } } },
-	"0x00Ea169ce7e0992960D3BdE6F5D539C955316432": { "balance": "1606938044258990275541962092341162602522202993782792835301376" }  
+        "0x0000000000000000000000000000000000000005": { "builtin": { "name": "modexp", "activate_at": "0x0", "pricing": { "modexp": { "divisor": 20 } } } },
+        "0x0000000000000000000000000000000000000006": { "builtin": { "name": "alt_bn128_add", "activate_at": "0x0", "pricing": { "linear": { "base": 500, "word": 0 } } } },
+        "0x0000000000000000000000000000000000000007": { "builtin": { "name": "alt_bn128_mul", "activate_at": "0x0", "pricing": { "linear": { "base": 40000, "word": 0 } } } },
+        "0x0000000000000000000000000000000000000008": { "builtin": { "name": "alt_bn128_pairing", "activate_at": "0x0", "pricing": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 } } } },
+        "0x00Ea169ce7e0992960D3BdE6F5D539C955316432": { "balance": "1606938044258990275541962092341162602522202993782792835301376" }
     }

--- a/config/spec/accounts/validatorset
+++ b/config/spec/accounts/validatorset
@@ -3,5 +3,9 @@
         "0x0000000000000000000000000000000000000002": { "balance": "1", "builtin": { "name": "sha256", "pricing": { "linear": { "base": 60, "word": 12 } } } },
         "0x0000000000000000000000000000000000000003": { "balance": "1", "builtin": { "name": "ripemd160", "pricing": { "linear": { "base": 600, "word": 120 } } } },
         "0x0000000000000000000000000000000000000004": { "balance": "1", "builtin": { "name": "identity", "pricing": { "linear": { "base": 15, "word": 3 } } } },
-	"0x00Ea169ce7e0992960D3BdE6F5D539C955316432": { "balance": "1606938044258990275541962092341162602522202993782792835301376" }  
+        "0x0000000000000000000000000000000000000005": { "builtin": { "name": "modexp", "activate_at": "0x0", "pricing": { "modexp": { "divisor": 20 } } } },
+        "0x0000000000000000000000000000000000000006": { "builtin": { "name": "alt_bn128_add", "activate_at": "0x0", "pricing": { "linear": { "base": 500, "word": 0 } } } },
+        "0x0000000000000000000000000000000000000007": { "builtin": { "name": "alt_bn128_mul", "activate_at": "0x0", "pricing": { "linear": { "base": 40000, "word": 0 } } } },
+        "0x0000000000000000000000000000000000000008": { "builtin": { "name": "alt_bn128_pairing", "activate_at": "0x0", "pricing": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 } } } },
+        "0x00Ea169ce7e0992960D3BdE6F5D539C955316432": { "balance": "1606938044258990275541962092341162602522202993782792835301376" }
     }

--- a/config/spec/params/aura
+++ b/config/spec/params/aura
@@ -6,5 +6,12 @@
         "eip140Transition": "0x0",
         "eip211Transition": "0x0",
         "eip214Transition": "0x0",
-        "eip658Transition": "0x0"
+        "eip658Transition": "0x0",
+        "wasmActivationTransition": "0x0",
+        "eip145Transition": "0x0",
+        "eip1014Transition": "0x0",
+        "eip1052Transition": "0x0",
+        "eip1283Transition": "0x0",
+        "kip4Transition": "0x0",
+        "kip6Transition": "0x0"
     },

--- a/config/spec/params/aura
+++ b/config/spec/params/aura
@@ -2,5 +2,9 @@
         "maximumExtraDataSize": "0x20",
         "minGasLimit": "0x1388",
         "gasLimitBoundDivisor": "0x400",
-        "networkID" : "0x11"
+        "networkID" : "0x11",
+        "eip140Transition": "0x0",
+        "eip211Transition": "0x0",
+        "eip214Transition": "0x0",
+        "eip658Transition": "0x0"
     },

--- a/config/spec/params/instantseal
+++ b/config/spec/params/instantseal
@@ -2,5 +2,9 @@
 		"accountStartNonce": "0x0",
 		"maximumExtraDataSize": "0x20",
 		"minGasLimit": "0x1388",
-		"networkID" : "0x11"
+		"networkID" : "0x11",
+		"eip140Transition": "0x0",
+		"eip211Transition": "0x0",
+		"eip214Transition": "0x0",
+		"eip658Transition": "0x0"
 	},

--- a/config/spec/params/instantseal
+++ b/config/spec/params/instantseal
@@ -6,5 +6,12 @@
 		"eip140Transition": "0x0",
 		"eip211Transition": "0x0",
 		"eip214Transition": "0x0",
-		"eip658Transition": "0x0"
+		"eip658Transition": "0x0",
+		"wasmActivationTransition": "0x0",
+		"eip145Transition": "0x0",
+		"eip1014Transition": "0x0",
+		"eip1052Transition": "0x0",
+		"eip1283Transition": "0x0",
+		"kip4Transition": "0x0",
+		"kip6Transition": "0x0"
 	},

--- a/config/spec/params/tendermint
+++ b/config/spec/params/tendermint
@@ -6,5 +6,12 @@
         "eip140Transition": "0x0",
         "eip211Transition": "0x0",
         "eip214Transition": "0x0",
-        "eip658Transition": "0x0"
+        "eip658Transition": "0x0",
+        "wasmActivationTransition": "0x0",
+        "eip145Transition": "0x0",
+        "eip1014Transition": "0x0",
+        "eip1052Transition": "0x0",
+        "eip1283Transition": "0x0",
+        "kip4Transition": "0x0",
+        "kip6Transition": "0x0"
     },

--- a/config/spec/params/tendermint
+++ b/config/spec/params/tendermint
@@ -2,5 +2,9 @@
         "maximumExtraDataSize": "0x20",
         "minGasLimit": "0x1388",
         "networkID" : "0x11",
-        "gasLimitBoundDivisor": "0x0400"
+        "gasLimitBoundDivisor": "0x0400",
+        "eip140Transition": "0x0",
+        "eip211Transition": "0x0",
+        "eip214Transition": "0x0",
+        "eip658Transition": "0x0"
     },

--- a/config/spec/params/validatorset
+++ b/config/spec/params/validatorset
@@ -6,5 +6,12 @@
         "eip140Transition": "0x0",
         "eip211Transition": "0x0",
         "eip214Transition": "0x0",
-        "eip658Transition": "0x0"
+        "eip658Transition": "0x0",
+        "wasmActivationTransition": "0x0",
+        "eip145Transition": "0x0",
+        "eip1014Transition": "0x0",
+        "eip1052Transition": "0x0",
+        "eip1283Transition": "0x0",
+        "kip4Transition": "0x0",
+        "kip6Transition": "0x0"
     },

--- a/config/spec/params/validatorset
+++ b/config/spec/params/validatorset
@@ -2,5 +2,9 @@
         "maximumExtraDataSize": "0x20",
         "minGasLimit": "0x1388",
         "gasLimitBoundDivisor": "0x400",
-        "networkID" : "0x11"
+        "networkID" : "0x11",
+        "eip140Transition": "0x0",
+        "eip211Transition": "0x0",
+        "eip214Transition": "0x0",
+        "eip658Transition": "0x0"
     },


### PR DESCRIPTION
By default, there is no byzantium tag set in params and account config of poa chain spec templates.

When interacted with poa created without byzantium eip tags,  client (like web3js) may think transaction are reverted because of mismatch  "status" value in the transaction receipt (eip658Transition). See example impact here: https://github.com/paritytech/parity-bridge/issues/196#issuecomment-425129873

This pull request is the addition of byzantium config params by default in poa setup. Default config setup like indicated here :  
https://github.com/paritytech/parity-ethereum/issues/7124#issuecomment-346647725

