### PR TITLE
osx port

### DIFF
--- a/config/utils/keygen.sh
+++ b/config/utils/keygen.sh
@@ -2,9 +2,11 @@
 TMPFILE=`mktemp`
 export PATH=$PATH:.
 
+OS=`uname -s`
+ARCH=`uname -m`
+
 if [ ! $(type -P ethkey) ];  then
-    ARCH=`arch`
-    ETHKEY_URL=`curl -sS "https://vanity-service.parity.io/parity-binaries?version=stable&format=markdown&os=linux&architecture=$ARCH" | grep ethkey | awk {'print $5'}  | cut -d"(" -f2 | cut -d")" -f1`
+    ETHKEY_URL=`curl -sS "https://vanity-service.parity.io/parity-binaries?version=stable&format=markdown&os=$OS&architecture=$ARCH" | grep ethkey | awk {'print $5'}  | cut -d"(" -f2 | cut -d")" -f1`
     wget -q $ETHKEY_URL
     chmod +x ethkey
 fi
@@ -12,10 +14,8 @@ fi
 
 # Generate the private and public keys
 ethkey generate random > $TMPFILE
- 
+
 cat $TMPFILE | grep public | awk {'print $2'} > $1/key.pub
 cat $TMPFILE | grep secret | awk {'print $2'} > $1/key.priv
 
 rm -rf $TMPFILE
-
-

--- a/parity-deploy.sh
+++ b/parity-deploy.sh
@@ -3,18 +3,24 @@
 
 sed() {
   if [ "$(uname)" = "Darwin" ] ; then
-    gsed "$@"
+    gsed $@
   else
-    command sed "$@"
+    command sed $@
   fi
 }
+
+if [ "$(uname)" = "Darwin" ] ; then
+  alias sed='gsed'
+fi
 
 mktemp() {
   if [ "$(uname)" = "Darwin" ]; then
     if [ "$1" = "-p" ]; then
-      shift;
+      shift
     fi
-    command mktemp $1/$2
+    if [ $# == 2 ]; then
+      command mktemp $1/$2
+    fi
   else
     command mktemp $@
   fi
@@ -46,17 +52,24 @@ NOTE:
 
 check_packages() {
 
-if [ $(grep -i debian /etc/*-release | wc -l) -gt 0 ] ; then
-   if [ ! -f /usr/local/bin/docker ] ; then
-      #sudo apt-get -y install docker.io python-pip
-      brew install docker.io python-pip
-   fi
+  if [ "$(uname)" = "Darwin" ] ; then
+    if [ ! -f /usr/local/bin/docker ] ; then
+       brew install docker.io python-pip
+    fi
 
-   if [ ! -f /usr/local/bin/docker-compose ] ; then
-      #sudo pip install docker-compose
-      brew install docker-compose
+    if [ ! -f /usr/local/bin/docker-compose ] ; then
+       brew install docker-compose
+    fi
+ else if [ $(grep -i debian /etc/*-release | wc -l) -gt 0 ] ; then
+     if [ ! -f /usr/bin/docker ] ; then
+        sudo apt-get -y install docker.io python-pip
+     fi
+
+     if [ ! -f /usr/local/bin/docker-compose ] ; then
+        sudo pip install docker-compose
+     fi
    fi
-fi
+  fi
 }
 
 

--- a/parity-deploy.sh
+++ b/parity-deploy.sh
@@ -3,9 +3,9 @@
 
 sed() {
   if [ "$(uname)" = "Darwin" ] ; then
-    gsed $@
+    gsed "$@"
   else
-    command sed $@
+    command sed "$@"
   fi
 }
 
@@ -90,7 +90,7 @@ fi
 echo '' > $DEST_DIR/password
 ./config/utils/keygen.sh $DEST_DIR
 
-local SPEC_FILE=$(mktemp $DEST_DIR/spec.XXXXXXXXX)
+local SPEC_FILE=$(mktemp -p $DEST_DIR spec.XXXXXXXXX)
 sed "s/CHAIN_NAME/$CHAIN_NAME/g" config/spec/example.spec > $SPEC_FILE
 parity --chain $SPEC_FILE --keys-path $DEST_DIR/ account new --password $DEST_DIR/password  > $DEST_DIR/address.txt
 rm $SPEC_FILE


### PR DESCRIPTION
backward compatible. relies on
brew instead of `apt-get for installing `docker` and `python` 
`gsed` instead of `sed`
`uname` instead of `arch`  