### PR TITLE
fix spec gasLimitBoundDivisor

### DIFF
--- a/config/spec/engine/aura
+++ b/config/spec/engine/aura
@@ -1,7 +1,6 @@
     	"engine": {
         "authorityRound": {
             "params": {
-                "gasLimitBoundDivisor": "0x400",
                 "stepDuration": "2",
                 "validators" : {
                     "list": [ 0x0000000000000000000000000000000000000000 ]
@@ -9,4 +8,3 @@
             }
         }
     },
-

--- a/config/spec/engine/validatorset
+++ b/config/spec/engine/validatorset
@@ -1,7 +1,6 @@
        "engine": {
         "authorityRound": {
             "params": {
-                "gasLimitBoundDivisor": "0x400",
                 "stepDuration": "2",
                 "validators" : {
                 "multi": {
@@ -17,4 +16,3 @@
             }
         }
      },
-

--- a/config/spec/example.spec
+++ b/config/spec/example.spec
@@ -3,7 +3,6 @@
       "engine": {
         "authorityRound": {
             "params": {
-                "gasLimitBoundDivisor": "0x400",
                 "stepDuration": "2",
                 "validators" : {
                     "list": [ "0x0000000000000000000000000000000000000000" ]


### PR DESCRIPTION

Ethereum client now check Chain spec validity: 
https://github.com/paritytech/parity-ethereum/pull/9972

Must remove gasLimitBoundDivisor from the wrong place to fix : 
https://github.com/paritytech/parity-deploy/issues/87