### PR TITLE
Use uname -m instead of arch command

### DIFF
--- a/config/utils/keygen.sh
+++ b/config/utils/keygen.sh
@@ -3,7 +3,7 @@ TMPFILE=`mktemp`
 export PATH=$PATH:.
 
 if [ ! $(type -P $PWD/ethkey) ];  then
-    ARCH=`arch`
+    ARCH=`uname -m`
     ETHKEY_URL=`curl -sS "https://vanity-service.parity.io/parity-binaries?version=stable&format=markdown&os=linux&architecture=$ARCH" | grep ethkey | awk {'print $5'}  | cut -d"(" -f2 | cut -d")" -f1`
     wget -q $ETHKEY_URL
     chmod +x ethkey


### PR DESCRIPTION
Fixes downloading ethkey on arch linux