### PR TITLE
add chain name variable instead of parity default value

### DIFF
--- a/parity-deploy.sh
+++ b/parity-deploy.sh
@@ -58,7 +58,7 @@ create_node_params() {
 
 	PASSWORD=$(cat $DEST_DIR/password)
 	PRIV_KEY=$(cat $DEST_DIR/key.priv)
-	./ethstore insert ${PRIV_KEY} $DEST_DIR/password --dir $DEST_DIR/parity >$DEST_DIR/address.txt
+	./ethstore insert ${PRIV_KEY} $DEST_DIR/password --dir $DEST_DIR/$CHAIN_NAME >$DEST_DIR/address.txt
 
 	echo "NETWORK_NAME=$CHAIN_NAME" >.env
 


### PR DESCRIPTION
Name is hardcoded in the script [here](https://github.com/paritytech/parity-deploy/blob/master/parity-deploy.sh#L61) so when setting a custom name different from "parity" (the default name) the start will fail.

- `docker-compose up `OK with default name = parity
```
./parity-deploy.sh --config aura
```

- `docker-compose up` KO with key missing in Keys path /home/parity/data/keys/customName
```
./parity-deploy.sh --config aura --name customName
```

```
~/parity-deploy$ docker-compose up
Starting host1 ... done
Attaching to host1
host1    | Loading config file from /home/parity/authority.toml
host1    | 2019-03-19 13:47:37 UTC Starting Parity-Ethereum/v2.3.6-stable-7aab6b7-20190319/x86_64-linux-gnu/rustc1.33.0
host1    | 2019-03-19 13:47:37 UTC Keys path /home/parity/data/keys/customName
host1    | 2019-03-19 13:47:37 UTC DB path /home/parity/data/chains/customName/db/2b60f78822e95081
host1    | 2019-03-19 13:47:37 UTC State DB configuration: fast
host1    | 2019-03-19 13:47:37 UTC Operating mode: active
host1    | Consensus signer account not found for the current chain. You can create an account via RPC, UI or `parity account new --chain /home/parity/spec.json --keys-path /home/parity/data/keys`.
```


because the key is not generate at the right place.

This commit replace `--dir $DEST_DIR/parity` by  `--dir $DEST_DIR/$CHAIN_NAME` and solve this problem.